### PR TITLE
git-pulls the operator repo clone before running apply_tc_rules.sh.

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -11,7 +11,7 @@ coreos:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/docker exec script-exporter /bin/apply_tc_rules.sh
+        ExecStart=/bin/docker exec script-exporter bash -c 'git -C /opt/mlab/operator pull && /bin/apply_tc_rules.sh'
     - name: apply-tc-rules.timer
       command: "start"
       content: |


### PR DESCRIPTION
This service gets run daily by a systemd timer, but it was previously fairly useless because the operator repo clone was never updated, so the tc rules never changed or were updated based on changes to sites.py. This PR addresses that by making the service to a pull on the local clone of the operator repo prior to running `apply_tc_rules.sh`.

Addresses issue #20.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/21)
<!-- Reviewable:end -->
