### PR TITLE
Add command: "start" to apply-tc-rules.service

### DIFF
--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -13,6 +13,10 @@ coreos:
         [Service]
         Type=oneshot
         ExecStart=/bin/docker exec script-exporter bash -c 'git -C /opt/mlab/operator pull && /bin/apply_tc_rules.sh'
+        
+        [Install]
+        WantedBy=multi-user.target
+
     - name: apply-tc-rules.timer
       command: "start"
       content: |

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -9,6 +9,8 @@ coreos:
       content: |
         [Unit]
         Description=Updates tc traffic shaping rules in the script-exporter container.
+        After=docker.service
+        Requires=docker.service
 
         [Service]
         Type=oneshot

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -13,7 +13,7 @@ coreos:
         [Service]
         Type=oneshot
         ExecStart=/bin/docker exec script-exporter bash -c 'git -C /opt/mlab/operator pull && /bin/apply_tc_rules.sh'
-        
+
         [Install]
         WantedBy=multi-user.target
 

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -28,12 +28,11 @@ coreos:
         [Install]
         WantedBy=multi-user.target
     - name: apply-tc-rules.service
-      command: start
       content: |
         [Unit]
         Description=Updates tc traffic shaping rules in the script-exporter container.
-        After=docker.service
-        Requires=docker.service
+        After=script-exporter.service
+        Requires=script-exporter.service
 
         [Service]
         Type=oneshot

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -4,6 +4,29 @@ coreos:
   units:
     - name: docker.service
       command: start
+    # Make sure the script-exporter container starts after the Docker daemon.
+    # This is initially not enabled, to avoid conflicts with the Travis
+    # deployment. After the script-exporter image has been pulled and run once,
+    # this service is enabled to make sure script-exporter is restarted after
+    # a reboot.
+    - name: script-exporter.service
+      content: |
+        [Unit]
+        Description=script-exporter Docker container
+        After=docker.service
+        Requires=docker.service
+
+        [Service]
+        TimeoutStartSec=0
+        Restart=always
+        ExecStartPre=-/usr/bin/docker stop ${GCE_NAME}
+        ExecStartPre=-/usr/bin/docker rm ${GCE_NAME}
+        ExecStart=docker run --detach --restart always
+          --publish ${INTERNAL_IP}:9172:9172 --name ${GCE_NAME}
+          --cap-add NET_ADMIN ${IMAGE_TAG}
+
+        [Install]
+        WantedBy=multi-user.target
     - name: apply-tc-rules.service
       command: start
       content: |
@@ -46,4 +69,3 @@ write_files:
       PasswordAuthentication no
       ChallengeResponseAuthentication no
       PermitRootLogin no
-

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -5,6 +5,7 @@ coreos:
     - name: docker.service
       command: start
     - name: apply-tc-rules.service
+      command: start
       content: |
         [Unit]
         Description=Updates tc traffic shaping rules in the script-exporter container.

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -94,3 +94,7 @@ gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --p
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
 gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish ${INTERNAL_IP}:9100:9100 --name node-exporter --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"
+
+# Enable docker.script-exporter.service so that script-exporter restarts after
+# a reboot.
+gcloud compute ssh $GCE_NAME --command "systemctl enable script-exporter"

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -95,6 +95,7 @@ gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --p
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
 gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish ${INTERNAL_IP}:9100:9100 --name node-exporter --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"
 
-# Enable docker.script-exporter.service so that script-exporter restarts after
-# a reboot.
+# Enable script-exporter and apply-tc-rules services so that they are run at
+# subsequent boots.
 gcloud compute ssh $GCE_NAME --command "systemctl enable script-exporter"
+gcloud compute ssh $GCE_NAME --command "systemctl enable apply-tc-rules"


### PR DESCRIPTION
This change should make sure `git pull` is run as soon as we deploy this repo.
Subsequent runs will be still determined by the apply-tc-rules.timer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/23)
<!-- Reviewable:end -->
