### PR TITLE
Migrates apply-tc-rules.sh off of sites.py and onto siteinfo sites.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM debian:stretch-slim
+FROM golang:1.11-stretch
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
+RUN apt update -qq && apt install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo "deb https://deb.nodesource.com/node_0.12 jessie main" > /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -qq && apt-get install -qq nodejs=0.12.18-1nodesource1~jessie1
+RUN apt update -qq && apt install -qq nodejs=0.12.18-1nodesource1~jessie1
 RUN npm install --global --quiet minimist@1.2.0 ws@1.0.1
 
 # Clone necessary git repos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.11-stretch
 
 # Install necessary packages
-RUN apt update -qq && apt install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo "deb https://deb.nodesource.com/node_0.12 jessie main" > /etc/apt/sources.list.d/nodesource.list
-RUN apt update -qq && apt install -qq nodejs=0.12.18-1nodesource1~jessie1
+RUN apt-get update -qq && apt-get install -qq nodejs=0.12.18-1nodesource1~jessie1
 RUN npm install --global --quiet minimist@1.2.0 ws@1.0.1
 
 # Clone necessary git repos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11-stretch
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https dnsutils golang jq sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https dnsutils jq sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11-stretch
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang jq iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https dnsutils golang jq sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -

--- a/apply_tc_rules.sh
+++ b/apply_tc_rules.sh
@@ -39,12 +39,12 @@ ingress_filters=$(tc filter show dev eth0 parent ffff:)
 for ip in $NDT_IPS; do
   HEX_IP=$(printf '%02x' ${ip//./ })
   # Only add the egress filter for this IP if it doesn't already exist.
-  if ! echo "${egress_filters}" | grep "${HEX_IP}"; then
+  if ! echo "${egress_filters}" | grep "${HEX_IP}" > /dev/null; then
     tc filter add dev eth0 parent 1: protocol ip prio 1 \
         u32 match ip dst ${ip} flowid 1:10
   fi
   # Only add the ingress filter for this IP if it doesn't already exist.
-  if ! echo "${ingress_filters}" | grep "${HEX_IP}"; then
+  if ! echo "${ingress_filters}" | grep "${HEX_IP}" > /dev/null; then
     tc filter add dev eth0 parent ffff: protocol ip prio 1 \
         u32 match ip src ${ip} police rate 50kbps burst 10k drop
   fi

--- a/apply_tc_rules.sh
+++ b/apply_tc_rules.sh
@@ -25,8 +25,8 @@ fi
 #
 # First, erase all existing configurations.
 #
-tc qdisc del dev eth0 root
-tc qdisc del dev eth0 ingress 
+tc qdisc del dev eth0 root || true
+tc qdisc del dev eth0 ingress || true
 
 #
 # Add root queues.

--- a/apply_tc_rules.sh
+++ b/apply_tc_rules.sh
@@ -33,16 +33,18 @@ tc class add dev eth0 parent 1: classid 1:10 htb rate 5mbit || :
 # Add filters for each NDT IP address. egress traffic matching a destination IP
 # address of an NDT experiment gets queued into class id 1:10.  ingress traffic
 # with a source IP matching one of the NDT slivers gets policed at 50Kbps.
+egress_filters=$(tc filter show dev eth0 parent 1:)
+ingress_filters=$(tc filter show dev eth0 parent ffff:)
 
 for ip in $NDT_IPS; do
   HEX_IP=$(printf '%02x' ${ip//./ })
   # Only add the egress filter for this IP if it doesn't already exist.
-  if ! tc filter show dev eth0 parent 1: | grep "${HEX_IP}"; then
+  if ! echo "${egress_filters}" | grep "${HEX_IP}"; then
     tc filter add dev eth0 parent 1: protocol ip prio 1 \
         u32 match ip dst ${ip} flowid 1:10
   fi
   # Only add the ingress filter for this IP if it doesn't already exist.
-  if ! tc filter show dev eth0 parent ffff: | grep "${HEX_IP}"; then
+  if ! echo "${ingress_filters}" | grep "${HEX_IP}"; then
     tc filter add dev eth0 parent ffff: protocol ip prio 1 \
         u32 match ip src ${ip} police rate 50kbps burst 10k drop
   fi

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -11,7 +11,7 @@ coreos:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/docker exec script-exporter bash -c '/bin/apply_tc_rules.sh'
+        ExecStart=/bin/docker exec script-exporter /bin/apply_tc_rules.sh
     - name: apply-tc-rules.timer
       command: "start"
       content: |

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -19,7 +19,7 @@ coreos:
         Description=Run apply-tc-rules.service daily.
 
         [Timer]
-        OnCalendar=daily
+        OnCalendar=Mon..Fri 15:00:00
 
         [Install]
         WantedBy=multi-user.target

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -11,7 +11,7 @@ coreos:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/docker exec script-exporter bash -c 'git -C /opt/mlab/operator pull && /bin/apply_tc_rules.sh'
+        ExecStart=/bin/docker exec script-exporter bash -c '/bin/apply_tc_rules.sh'
     - name: apply-tc-rules.timer
       command: "start"
       content: |


### PR DESCRIPTION
The script-exporter-support script `apply-tc-rules.sh` currently has a dependency on an output format of mlabconfig.py that it no longer supports now that siteinfo is the canonical source of site information. This PR converts the apply-tc-rules.sh script to start using sites.json from the siteinfo "API" instead of mlabconfig.py. 

Also, presently the first thing apply-tc-rules.sh does is to delete all qdiscs and rules. If any of the following steps fail, then no tc rules will be set up, and if no tc rules are configured for a given IP, then ndt_e2e.sh will refuse to run and exits with an error. This can flag the entire NDT fleet as being down, causing an fleetwide outage for those clients that use mlab-ns.

This PR moves the logic of successfully fetching the NDT IP addresses before doing anything else to avoid the above issue.

Also, this PR moves the base Docker image from `debian:stretch-slim` to `golang:1.11-stretch` because the version of Go in stock Stretch is to old to even build the tools needed by the script_exporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/24)
<!-- Reviewable:end -->
