### PR TITLE
Add status-only queueing test to reduce false-error rate

### DIFF
--- a/script_exporter.yml
+++ b/script_exporter.yml
@@ -4,8 +4,11 @@ scripts:
     timeout: 45
 
   - name: 'ndt_queue'
+    # NOTE: we specify "--tests 16" to request a STATUS test, which is a
+    # "no-op" request to the server that also does not register as upload or
+    # downloads errors on the server.
     script: >
       NODE_PATH=/usr/lib/node_modules
       nodejs /opt/mlab/ndt/src/node_tests/ndt_client.js --queueingtest
-      --server ${TARGET} --protocol wss --port 3010
+      --server ${TARGET} --protocol wss --port 3010 --tests 16
     timeout: 15


### PR DESCRIPTION
Part of https://github.com/m-lab/ndt-server/issues/166

By default, the queueing test requests a test suite including "c2s + s2c + meta" -- but will never run them. In the new ndt-server, tests requested but never run are counted as an error.

This change modifies the requested test suite to only include the STATUS message. This way, the other tests are never attempted and never error.

Example debug output from the current and new platforms. As well, I verified ad-hoc that the web100-ndt server can return QUEUE messages when STATUS tests are requested. (ran the queuing check in background in a loop until server started to queue (mlab2.lga1t).

```
# NODE_PATH=/usr/lib/node_modules nodejs /opt/mlab/ndt/src/node_tests/ndt_client.js --queueingtest --debug --server ndt-iupui-mlab4-lga03.measurement-lab.org --protocol wss --port 3010 --tests 16 ; echo $?
Running NDT test to wss://ndt-iupui-mlab4-lga03.measurement-lab.org:3010/ndt_protocol
OPENED CONNECTION
type = 1 (SRV_QUEUE) body = '0'
There will be a 0 minute wait for the test to start
Got SRV_QUEUE. Ignoring and waiting for MSG_LOGIN
type = 2 (MSG_LOGIN) body = 'v5.0-NDTinGO'
Received MSG_LOGIN. Server is not queueing.
0

# NODE_PATH=/usr/lib/node_modules nodejs /opt/mlab/ndt/src/node_tests/ndt_client.js --queueingtest --debug --server ndt-iupui-mlab1-lga03.measurement-lab.org --protocol wss --port 3010 --tests 16 ; echo $?
Running NDT test to wss://ndt-iupui-mlab1-lga03.measurement-lab.org:3010/ndt_protocol
OPENED CONNECTION
type = 1 (SRV_QUEUE) body = '0'
There will be a 0 minute wait for the test to start
Got SRV_QUEUE. Ignoring and waiting for MSG_LOGIN
type = 2 (MSG_LOGIN) body = 'v4.0.0.1-Web100'
Received MSG_LOGIN. Server is not queueing.
0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/26)
<!-- Reviewable:end -->
