### PR TITLE
Fix evaluation bug

### DIFF
--- a/ndt_e2e.sh
+++ b/ndt_e2e.sh
@@ -83,7 +83,7 @@ echo $STATUS > $CACHE_DIR/$HOST
 # e2e test will run sooner than normal, but will hopefully cause the cached
 # statuses to expire at randomly different times and spread the NDT e2e test
 # load across the entire expiration interval.
-if [[ $FIRST_RUN ]]; then
+if [[ $FIRST_RUN = "true" ]]; then
     RAND=$(($RANDOM % $MAX_CACHE_AGE))
     touch --date "${RAND} seconds ago" $CACHE_DIR/$HOST
 fi


### PR DESCRIPTION
This change fixes a bug in ndt_e2e.sh that causes `$FIRST_RUN=false` to evaluate to true unconditionally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/28)
<!-- Reviewable:end -->
