### PR TITLE
Deploy on specific tag patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ deploy:
     skip_cleanup: true
     on:
       repo: m-lab/script-exporter-support
-      tags: true
+      all_branches: true
+      condition: $TRAVIS_TAG == production*


### PR DESCRIPTION
This repo contains two different deployment paths now: GCE script-exporter and dockerhub build of the Dockerfile.minimal for GKE.

This PR changes the condition on production deployments to match the `production*` pattern. This preserves the current behavior for historical tag names. And, it ignores `v[0-9.]+` patterns which are recognized by dockerhub.

This change will allow deploying of each independently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/30)
<!-- Reviewable:end -->
