### PR TITLE
Allows for unique return status caching directories

### DIFF
--- a/cache_exit_code.sh
+++ b/cache_exit_code.sh
@@ -12,6 +12,21 @@ if [[ -z "$TARGET" ]] ; then
     exit $STATE_CRITICAL
 fi
 
+if [[ -z "$EXPERIMENT" ]] ; then
+    echo 'ERROR: must define EXPERIMENT from environment'
+    exit $STATE_CRITICAL
+fi
+
+if [[ -z ${1} ]]; then
+    echo "ERROR: missing TTL for command (arg 1)"
+    exit $STATE_CRITICAL
+fi
+
+if [[ -z ${2} ]]; then
+    echo "ERROR: missing command to run (arg 2)"
+    exit $STATE_CRITICAL
+fi
+
 if [[ -n "$LOGX_DEBUG" ]] ; then
     # Enable additional execution logs for debugging.
     set -x
@@ -22,10 +37,10 @@ set -u
 
 # Max age (in seconds) to use a cached command result before running the
 # command again.
-MAX_CACHE_AGE=${1:?Please provide timeout value}
+MAX_CACHE_AGE=${1}
 
 # Where to store cached exit codes from the given command.
-CACHE_DIR=/tmp/cache-${2:?Please provide a command to run}
+CACHE_DIR=/tmp/cache-${EXPERIMENT}
 
 # If the $CACHE_DIR doesn't exist create it.
 if [[ ! -d $CACHE_DIR ]]; then


### PR DESCRIPTION
Currently, if more than one script requires the `monitoring-token` command to run, then the cache directories will no longer be unique and you will have collisions, as all cache directories will be located at `/tmp/cache-monitoring-token`. This PR introduces the use of a new environment variable `EXPERIMENT` which will be used to create a unique cache directory like `/tmp/cache-${EXPERIMENT}`. The variable will be introduced into the environment directly from the script-exporter config YAML file like:

```
scripts:
- name: "rofl"
  script: EXPERIMENT=rofl monitoring-token <etc>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/34)
<!-- Reviewable:end -->
