### PR TITLE
Installs tini and uses it as PID 1

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -6,10 +6,12 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 RUN go get github.com/m-lab/locate/cmd/monitoring-token
 
 # Install java for the wehe cli client, and clone client repo
-RUN apt update && apt install --yes openjdk-11-jre-headless
+# Install tini: https://github.com/krallin/tini
+RUN apt update && apt install --yes openjdk-11-jre-headless tini
 RUN git clone https://github.com/dng24/wehe-cmdline
 
 COPY ./cache_exit_code.sh ./wehe-client.sh /usr/bin/
 
 EXPOSE 9172
-ENTRYPOINT ["/go/bin/script_exporter"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/go/bin/script_exporter"]


### PR DESCRIPTION
We discovered that script_exporter has a problem with orphaned processes in the case where script_exporter terminates its shell while the scripts are still running. This PR adds a new tiny init ("tini") utility which can be PID 1. With this configuration, when a process gets orphaned it will be reparented to tini, which will reap it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/36)
<!-- Reviewable:end -->
