### PR TITLE
Moves script_exporter command to ENTRYPOINT

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -13,5 +13,5 @@ RUN git clone https://github.com/dng24/wehe-cmdline
 COPY ./cache_exit_code.sh ./wehe-client.sh /usr/bin/
 
 EXPOSE 9172
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["/go/bin/script_exporter"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/go/bin/script_exporter"]
+


### PR DESCRIPTION
We use the `args` key in our k8s manifest for script_exporter, which overrides anything defined in `CMD` in the Dockerfile. This PR moves the script_exporter command to ENTRYPOINT so that the k8s manifest can stay as it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/37)
<!-- Reviewable:end -->
