### PR TITLE
Updates Dockerfile to point to more official wehe-cmdline repo

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -8,7 +8,7 @@ RUN go get github.com/m-lab/locate/cmd/monitoring-token
 # Install java for the wehe cli client, and clone client repo
 # Install tini: https://github.com/krallin/tini
 RUN apt update && apt install --yes openjdk-11-jre-headless tini
-RUN git clone https://github.com/dng24/wehe-cmdline
+RUN git clone https://github.com/NEU-SNS/wehe-cmdline
 
 COPY ./cache_exit_code.sh ./wehe-client.sh /usr/bin/
 


### PR DESCRIPTION
Currently, the Dockerfile points to a repo in a personal Github account. The repo was moved to more official NEU account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/38)
<!-- Reviewable:end -->
