### PR TITLE
Removes log files written by wehe-cmdline.

### DIFF
--- a/wehe-client.sh
+++ b/wehe-client.sh
@@ -9,3 +9,6 @@
 
 java -jar wehe-cmdline/wehe-cmdline.jar -m $MONITORING_URL $@
 
+# Remove any log files written by the test.
+rm -rf ./test_results
+


### PR DESCRIPTION
Today I noticed quite a lot of evicted script-exporter pods in production. Inspecting the pods they were all evicted for "DiskPressure", which means that the disk was filling up or too many inodes were being used.  Every wehe-cmdline test writes at least 2 files to disk. They are small text files, but the number of them adds up quickly in production. Eyeing it, it looks like around 5 files are written every second or so. The inode limit in the script-exporter pod is 6,258,720. It seems that under those conditions it could take around 14 days to use up every available inode, if my math is correct: 6258720 / 5 / 60 / 60 / 24

This PR modifies wehe-client.sh to remove the `test_results/` directory after every run, since we have no use for those logs, and they are likely causing problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/39)
<!-- Reviewable:end -->
