### PR TITLE
Explicit value check for logging

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,9 +1,9 @@
-FROM golang:1.15-buster
+FROM golang:1.18
 
 # Install script_exporter and dependencies.
-RUN go get github.com/m-lab/script_exporter
-RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
-RUN go get github.com/m-lab/locate/cmd/monitoring-token
+RUN go install github.com/m-lab/script_exporter@v1.2.0
+RUN go install github.com/m-lab/ndt5-client-go/cmd/ndt5-client@v0.1.0
+RUN go install github.com/m-lab/locate/cmd/monitoring-token@v0.14.10
 
 # Install java for the wehe cli client, and clone client repo
 # Install tini: https://github.com/krallin/tini

--- a/cache_exit_code.sh
+++ b/cache_exit_code.sh
@@ -27,10 +27,10 @@ if [[ -z ${2} ]]; then
     exit $STATE_CRITICAL
 fi
 
-if [[ -n "$LOGX_DEBUG" ]] ; then
+if [[ "$LOGX_DEBUG" == "true" ]] ; then
     # Enable additional execution logs for debugging.
     set -x
-    exec 1>> /tmp/${TARGET}.log 2>&1
+    exec 1> /tmp/${TARGET}.log 2>&1
 fi
 
 set -u


### PR DESCRIPTION
This change explicitly checks the value of `LOGX_DEBUG == true` to decide to log command output. The output log is also truncated on every invocation, rather than appended to indefinitely.

Bug found from https://github.com/m-lab/prometheus-support/pull/974 and script-exporter disk utilization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/40)
<!-- Reviewable:end -->
