### PR TITLE
Add ndt7-client

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -3,6 +3,7 @@ FROM golang:1.18
 # Install script_exporter and dependencies.
 RUN go install github.com/m-lab/script_exporter@v1.2.0
 RUN go install github.com/m-lab/ndt5-client-go/cmd/ndt5-client@v0.1.0
+RUN go install github.com/m-lab/ndt7-client-go/cmd/ndt7-client@v0.9.0
 RUN go install github.com/m-lab/locate/cmd/monitoring-token@v0.14.10
 
 # Install java for the wehe cli client, and clone client repo


### PR DESCRIPTION
This change adds the ndt7-client to the minimal script-exporter support image.

This makes it possible to have monitoring and automation targeting the autonode servers in sandbox and staging (and possibly production).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/41)
<!-- Reviewable:end -->
