### PR TITLE
Updates openjdk package from version 11 to 17

### DIFF
--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -8,7 +8,7 @@ RUN go install github.com/m-lab/locate/cmd/monitoring-token@v0.14.10
 
 # Install java for the wehe cli client, and clone client repo
 # Install tini: https://github.com/krallin/tini
-RUN apt update && apt install --yes openjdk-11-jre-headless tini
+RUN apt update && apt install --yes openjdk-17-jre-headless tini
 RUN git clone https://github.com/NEU-SNS/wehe-cmdline
 
 COPY ./cache_exit_code.sh ./wehe-client.sh /usr/bin/


### PR DESCRIPTION
Running the wehe client with version 11 yielded an error that mobi/meddle/wehe/Main was compiled with a more recent version of the Java Runtime than was installed on the system. This change seems to resolve that issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script-exporter-support/42)
<!-- Reviewable:end -->
